### PR TITLE
#1 Use headers to derive source and target

### DIFF
--- a/src/main/java/com/integreety/yatspec/e2e/teststate/interaction/InteractionNameGenerator.java
+++ b/src/main/java/com/integreety/yatspec/e2e/teststate/interaction/InteractionNameGenerator.java
@@ -10,10 +10,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import static com.integreety.yatspec.e2e.teststate.indent.JsonPrettyPrinter.indentJson;
 import static com.integreety.yatspec.e2e.teststate.indent.XmlPrettyPrinter.indentXml;
+import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -26,8 +29,9 @@ public class InteractionNameGenerator {
 
         final List<Pair<String, Object>> interactions = new ArrayList<>();
         for (final InterceptedInteraction interceptedInteraction : interceptedInteractions) {
-            final String destination = destinationNameMappings.mapForPath(interceptedInteraction.getTarget());
-            final String source = sourceNameMappings.mapFor(Pair.of(interceptedInteraction.getServiceName(), interceptedInteraction.getTarget()));
+            var headers = interceptedInteraction.getHeaders();
+            final String destination = deriveDestinationName(destinationNameMappings, interceptedInteraction, headers);
+            final String source = deriveSourceName(sourceNameMappings, interceptedInteraction, headers);
             reportRenderer.log(interceptedInteraction.getServiceName(), interceptedInteraction.getTarget(), source, destination);
             final String interactionName = interceptedInteraction.getType().getInteractionName().apply(buildInteraction(interceptedInteraction, source, destination));
             log.info("Generated an interaction name={}", interactionName);
@@ -35,6 +39,18 @@ public class InteractionNameGenerator {
             interactions.add(Pair.of(interactionName, body));
         }
         return interactions;
+    }
+
+    private String deriveSourceName(SourceNameMappings sourceNameMappings, InterceptedInteraction interceptedInteraction, Map<String, Collection<String>> headers) {
+        return isNotEmpty(headers) && headers.containsKey("Source-Name")
+                ? headers.get("Source-Name").stream().findFirst().orElse("")
+                : sourceNameMappings.mapFor(Pair.of(interceptedInteraction.getServiceName(), interceptedInteraction.getTarget()));
+    }
+
+    private String deriveDestinationName(DestinationNameMappings destinationNameMappings, InterceptedInteraction interceptedInteraction, Map<String, Collection<String>> headers) {
+        return isNotEmpty(headers) && headers.containsKey("Target-Name")
+                ? headers.get("Target-Name").stream().findFirst().orElse("")
+                : destinationNameMappings.mapForPath(interceptedInteraction.getTarget());
     }
 
     private Interaction buildInteraction(final InterceptedInteraction interceptedInteraction, final String source, final String destination) {

--- a/src/main/java/com/integreety/yatspec/e2e/teststate/interaction/InteractionNameGenerator.java
+++ b/src/main/java/com/integreety/yatspec/e2e/teststate/interaction/InteractionNameGenerator.java
@@ -22,6 +22,9 @@ import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 @RequiredArgsConstructor
 public class InteractionNameGenerator {
 
+    public static final String SOURCE_NAME_KEY = "Source-Name";
+    public static final String TARGET_NAME_KEY = "Target-Name";
+
     public List<Pair<String, Object>> generate(final SourceNameMappings sourceNameMappings,
                                                final DestinationNameMappings destinationNameMappings,
                                                final List<InterceptedInteraction> interceptedInteractions,
@@ -42,14 +45,14 @@ public class InteractionNameGenerator {
     }
 
     private String deriveSourceName(SourceNameMappings sourceNameMappings, InterceptedInteraction interceptedInteraction, Map<String, Collection<String>> headers) {
-        return isNotEmpty(headers) && headers.containsKey("Source-Name")
-                ? headers.get("Source-Name").stream().findFirst().orElse("")
+        return isNotEmpty(headers) && headers.containsKey(SOURCE_NAME_KEY)
+                ? headers.get(SOURCE_NAME_KEY).stream().findFirst().orElse("")
                 : sourceNameMappings.mapFor(Pair.of(interceptedInteraction.getServiceName(), interceptedInteraction.getTarget()));
     }
 
     private String deriveDestinationName(DestinationNameMappings destinationNameMappings, InterceptedInteraction interceptedInteraction, Map<String, Collection<String>> headers) {
-        return isNotEmpty(headers) && headers.containsKey("Target-Name")
-                ? headers.get("Target-Name").stream().findFirst().orElse("")
+        return isNotEmpty(headers) && headers.containsKey(TARGET_NAME_KEY)
+                ? headers.get(TARGET_NAME_KEY).stream().findFirst().orElse("")
                 : destinationNameMappings.mapForPath(interceptedInteraction.getTarget());
     }
 

--- a/src/test/java/com/integreety/yatspec/e2e/integration/InteractionNameGeneratorIT.java
+++ b/src/test/java/com/integreety/yatspec/e2e/integration/InteractionNameGeneratorIT.java
@@ -63,7 +63,11 @@ public class InteractionNameGeneratorIT {
     private static Stream<Arguments> provideInterceptedInteractions() {
         return Stream.of(
                 of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(REQUEST).httpMethod("POST").build(), "POST /abc/def from service to abc"),
+                of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(REQUEST).httpMethod("POST").headers(Map.of("Target-Name", List.of("Arnie"))).build(), "POST /abc/def from service to Arnie"),
+                of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(REQUEST).httpMethod("POST").headers(Map.of("Source-Name", List.of("Jean"))).build(), "POST /abc/def from Jean to abc"),
+                of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(REQUEST).httpMethod("POST").headers(Map.of("Source-Name", List.of("Jean"), "Target-Name", List.of("Arnie"))).build(), "POST /abc/def from Jean to Arnie"),
                 of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(RESPONSE).httpStatus("200").build(), "200 response from abc to service"),
+                of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(RESPONSE).httpStatus("200").headers(Map.of("Source-Name", List.of("Jean"), "Target-Name", List.of("Arnie"))).build(), "200 response from Arnie to Jean"),
                 of(InterceptedInteraction.builder().target("exchange").serviceName("service").body(BODY).type(PUBLISH).build(), "publish event from service to exchange"),
                 of(InterceptedInteraction.builder().target("exchange").serviceName("service").body(BODY).type(CONSUME).build(), "consume message from exchange to service")
         );
@@ -72,7 +76,9 @@ public class InteractionNameGeneratorIT {
     private static Stream<Arguments> provideInterceptedInteractionsWithSourceMappings() {
         return Stream.of(
                 of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(REQUEST).httpMethod("POST").build(), "POST /abc/def from source1 to abc"),
+                of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(REQUEST).httpMethod("POST").headers(Map.of("Source-Name", List.of("Jean"))).build(), "POST /abc/def from Jean to abc"),
                 of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(RESPONSE).httpStatus("200").build(), "200 response from abc to source1"),
+                of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(RESPONSE).httpStatus("200").headers(Map.of("Source-Name", List.of("Jean"))).build(), "200 response from abc to Jean"),
                 of(InterceptedInteraction.builder().target("exchange").serviceName("service").body(BODY).type(PUBLISH).build(), "publish event from source2 to exchange"),
                 of(InterceptedInteraction.builder().target("exchange").serviceName("service").body(BODY).type(CONSUME).build(), "consume message from exchange to source2")
         );
@@ -81,6 +87,7 @@ public class InteractionNameGeneratorIT {
     private static Stream<Arguments> provideInterceptedInteractionsWithDestinationMappings() {
         return Stream.of(
                 of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(REQUEST).httpMethod("POST").build(), "POST /abc/def from service to dest1"),
+                of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(REQUEST).httpMethod("POST").headers(Map.of("Target-Name", List.of("Arnie"))).build(), "POST /abc/def from service to Arnie"),
                 of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(RESPONSE).httpStatus("200").build(), "200 response from dest1 to service"),
                 of(InterceptedInteraction.builder().target("exchange").serviceName("service").body(BODY).type(PUBLISH).build(), "publish event from service to dest2"),
                 of(InterceptedInteraction.builder().target("exchange").serviceName("service").body(BODY).type(CONSUME).build(), "consume message from dest2 to service")


### PR DESCRIPTION
Initial attempt at adding ability to use headers to determine source and destination name mappings.

There may be a more elegant way but think this should open up the ability to simplify the config required for mapping particularly destination names in the meantime.