### PR TITLE
#5 Capture request headers for responses so that we can use the Targe…

### DIFF
--- a/src/main/java/com/integreety/yatspec/e2e/captor/repository/model/InterceptedInteraction.java
+++ b/src/main/java/com/integreety/yatspec/e2e/captor/repository/model/InterceptedInteraction.java
@@ -16,7 +16,8 @@ import java.util.Map;
 public class InterceptedInteraction {
     private String traceId;
     private String body;
-    private Map<String, Collection<String>> headers;
+    private Map<String, Collection<String>> requestHeaders;
+    private Map<String, Collection<String>> responseHeaders;
     private String serviceName; // the calling service or the publisher or consumer
     private String target; // the called URL or the exchange name
     private String httpStatus;

--- a/src/main/java/com/integreety/yatspec/e2e/captor/repository/model/InterceptedInteractionFactory.java
+++ b/src/main/java/com/integreety/yatspec/e2e/captor/repository/model/InterceptedInteractionFactory.java
@@ -7,6 +7,8 @@ import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.Map;
 
+import static java.util.Collections.emptyMap;
+
 @RequiredArgsConstructor
 public class InterceptedInteractionFactory {
 
@@ -19,14 +21,22 @@ public class InterceptedInteractionFactory {
         return buildFrom(body, headers, traceId, serviceName, target, null, null, type);
     }
 
-    public InterceptedInteraction buildFrom(final String body, final Map<String, Collection<String>> headers, final String traceId,
+    public InterceptedInteraction buildFrom(final String body, final Map<String, Collection<String>> requestHeaders, final String traceId,
+                                            final String serviceName, final String target, final String httpStatus,
+                                            final String httpMethod, final Type type) {
+
+        return buildFrom(body, requestHeaders, emptyMap(), traceId, serviceName, target, httpStatus, httpMethod, type);
+    }
+
+    public InterceptedInteraction buildFrom(final String body, final Map<String, Collection<String>> requestHeaders, final Map<String, Collection<String>> responseHeaders, final String traceId,
                                             final String serviceName, final String target, final String httpStatus,
                                             final String httpMethod, final Type type) {
 
         return InterceptedInteraction.builder()
                 .traceId(traceId)
                 .body(body)
-                .headers(headers)
+                .requestHeaders(requestHeaders)
+                .responseHeaders(responseHeaders)
                 .serviceName(serviceName)
                 .target(target)
                 .httpStatus(httpStatus)

--- a/src/main/java/com/integreety/yatspec/e2e/interceptor/LsdRestTemplateInterceptor.java
+++ b/src/main/java/com/integreety/yatspec/e2e/interceptor/LsdRestTemplateInterceptor.java
@@ -25,7 +25,7 @@ public class LsdRestTemplateInterceptor implements ClientHttpRequestInterceptor 
     public ClientHttpResponse intercept(final HttpRequest request, final byte[] body, final ClientHttpRequestExecution execution) throws IOException {
         final InterceptedInteraction interceptedInteraction = requestCaptor.captureRequestInteraction(request, new String(body));
         final ClientHttpResponse response = execution.execute(request, body);
-        responseCaptor.captureResponseInteraction(response, interceptedInteraction.getTarget(), interceptedInteraction.getTraceId());
+        responseCaptor.captureResponseInteraction(request, response, interceptedInteraction.getTarget(), interceptedInteraction.getTraceId());
         return response;
     }
 }

--- a/src/main/java/com/integreety/yatspec/e2e/teststate/interaction/InteractionNameGenerator.java
+++ b/src/main/java/com/integreety/yatspec/e2e/teststate/interaction/InteractionNameGenerator.java
@@ -32,7 +32,7 @@ public class InteractionNameGenerator {
 
         final List<Pair<String, Object>> interactions = new ArrayList<>();
         for (final InterceptedInteraction interceptedInteraction : interceptedInteractions) {
-            var headers = interceptedInteraction.getHeaders();
+            var headers = interceptedInteraction.getRequestHeaders();
             final String destination = deriveDestinationName(destinationNameMappings, interceptedInteraction, headers);
             final String source = deriveSourceName(sourceNameMappings, interceptedInteraction, headers);
             reportRenderer.log(interceptedInteraction.getServiceName(), interceptedInteraction.getTarget(), source, destination);

--- a/src/main/java/com/integreety/yatspec/e2e/teststate/interaction/InteractionNameGenerator.java
+++ b/src/main/java/com/integreety/yatspec/e2e/teststate/interaction/InteractionNameGenerator.java
@@ -32,9 +32,9 @@ public class InteractionNameGenerator {
 
         final List<Pair<String, Object>> interactions = new ArrayList<>();
         for (final InterceptedInteraction interceptedInteraction : interceptedInteractions) {
-            var headers = interceptedInteraction.getRequestHeaders();
-            final String destination = deriveDestinationName(destinationNameMappings, interceptedInteraction, headers);
-            final String source = deriveSourceName(sourceNameMappings, interceptedInteraction, headers);
+            var requestHeaders = interceptedInteraction.getRequestHeaders();
+            final String destination = deriveDestinationName(destinationNameMappings, interceptedInteraction, requestHeaders);
+            final String source = deriveSourceName(sourceNameMappings, interceptedInteraction, requestHeaders);
             reportRenderer.log(interceptedInteraction.getServiceName(), interceptedInteraction.getTarget(), source, destination);
             final String interactionName = interceptedInteraction.getType().getInteractionName().apply(buildInteraction(interceptedInteraction, source, destination));
             log.info("Generated an interaction name={}", interactionName);

--- a/src/test/java/com/integreety/yatspec/e2e/integration/EndToEndIT.java
+++ b/src/test/java/com/integreety/yatspec/e2e/integration/EndToEndIT.java
@@ -95,7 +95,7 @@ public class EndToEndIT {
         final List<InterceptedInteraction> interceptedInteractions = new ArrayList<>();
         await().untilAsserted(() -> {
             final List<InterceptedInteraction> foundInterceptedInteractions = testRepository.findAll(traceId);
-            assertThat(foundInterceptedInteractions, hasSize(6));
+            assertThat(foundInterceptedInteractions, hasSize(8));
             interceptedInteractions.addAll(foundInterceptedInteractions);
         });
 
@@ -120,7 +120,7 @@ public class EndToEndIT {
         assertThat(response.getStatusCode(), is(HttpStatus.OK));
         assertThat(response.getBody(), containsString("response_from_controller"));
 
-        await().untilAsserted(() -> assertThat(testRepository.findAll(traceId), hasSize(6)));
+        await().untilAsserted(() -> assertThat(testRepository.findAll(traceId), hasSize(8)));
 
         testStateLogger.logStatesFromDatabase(traceId, sourceNameMappings, destinationNameMappings);
 
@@ -131,6 +131,8 @@ public class EndToEndIT {
         assertThat(interactionNames, hasItem("consume message from Exchange to Consumer"));
         assertThat(interactionNames, hasItem("POST /external-api?message=from_feign from Consumer to Wiremock"));
         assertThat(interactionNames, hasItem("200 OK response from Wiremock to Consumer"));
+        assertThat(interactionNames, hasItem("POST /external-api?message=from_feign from Consumer to Downstream"));
+        assertThat(interactionNames, hasItem("200 OK response from Downstream to Consumer"));
     }
 
     @Test

--- a/src/test/java/com/integreety/yatspec/e2e/integration/InteractionNameGeneratorIT.java
+++ b/src/test/java/com/integreety/yatspec/e2e/integration/InteractionNameGeneratorIT.java
@@ -63,11 +63,11 @@ public class InteractionNameGeneratorIT {
     private static Stream<Arguments> provideInterceptedInteractions() {
         return Stream.of(
                 of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(REQUEST).httpMethod("POST").build(), "POST /abc/def from service to abc"),
-                of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(REQUEST).httpMethod("POST").headers(Map.of("Target-Name", List.of("Arnie"))).build(), "POST /abc/def from service to Arnie"),
-                of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(REQUEST).httpMethod("POST").headers(Map.of("Source-Name", List.of("Jean"))).build(), "POST /abc/def from Jean to abc"),
-                of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(REQUEST).httpMethod("POST").headers(Map.of("Source-Name", List.of("Jean"), "Target-Name", List.of("Arnie"))).build(), "POST /abc/def from Jean to Arnie"),
+                of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(REQUEST).httpMethod("POST").requestHeaders(Map.of("Target-Name", List.of("Arnie"))).build(), "POST /abc/def from service to Arnie"),
+                of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(REQUEST).httpMethod("POST").requestHeaders(Map.of("Source-Name", List.of("Jean"))).build(), "POST /abc/def from Jean to abc"),
+                of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(REQUEST).httpMethod("POST").requestHeaders(Map.of("Source-Name", List.of("Jean"), "Target-Name", List.of("Arnie"))).build(), "POST /abc/def from Jean to Arnie"),
                 of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(RESPONSE).httpStatus("200").build(), "200 response from abc to service"),
-                of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(RESPONSE).httpStatus("200").headers(Map.of("Source-Name", List.of("Jean"), "Target-Name", List.of("Arnie"))).build(), "200 response from Arnie to Jean"),
+                of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(RESPONSE).httpStatus("200").requestHeaders(Map.of("Source-Name", List.of("Jean"), "Target-Name", List.of("Arnie"))).build(), "200 response from Arnie to Jean"),
                 of(InterceptedInteraction.builder().target("exchange").serviceName("service").body(BODY).type(PUBLISH).build(), "publish event from service to exchange"),
                 of(InterceptedInteraction.builder().target("exchange").serviceName("service").body(BODY).type(CONSUME).build(), "consume message from exchange to service")
         );
@@ -76,9 +76,9 @@ public class InteractionNameGeneratorIT {
     private static Stream<Arguments> provideInterceptedInteractionsWithSourceMappings() {
         return Stream.of(
                 of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(REQUEST).httpMethod("POST").build(), "POST /abc/def from source1 to abc"),
-                of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(REQUEST).httpMethod("POST").headers(Map.of("Source-Name", List.of("Jean"))).build(), "POST /abc/def from Jean to abc"),
+                of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(REQUEST).httpMethod("POST").requestHeaders(Map.of("Source-Name", List.of("Jean"))).build(), "POST /abc/def from Jean to abc"),
                 of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(RESPONSE).httpStatus("200").build(), "200 response from abc to source1"),
-                of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(RESPONSE).httpStatus("200").headers(Map.of("Source-Name", List.of("Jean"))).build(), "200 response from abc to Jean"),
+                of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(RESPONSE).httpStatus("200").requestHeaders(Map.of("Source-Name", List.of("Jean"))).build(), "200 response from abc to Jean"),
                 of(InterceptedInteraction.builder().target("exchange").serviceName("service").body(BODY).type(PUBLISH).build(), "publish event from source2 to exchange"),
                 of(InterceptedInteraction.builder().target("exchange").serviceName("service").body(BODY).type(CONSUME).build(), "consume message from exchange to source2")
         );
@@ -87,7 +87,7 @@ public class InteractionNameGeneratorIT {
     private static Stream<Arguments> provideInterceptedInteractionsWithDestinationMappings() {
         return Stream.of(
                 of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(REQUEST).httpMethod("POST").build(), "POST /abc/def from service to dest1"),
-                of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(REQUEST).httpMethod("POST").headers(Map.of("Target-Name", List.of("Arnie"))).build(), "POST /abc/def from service to Arnie"),
+                of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(REQUEST).httpMethod("POST").requestHeaders(Map.of("Target-Name", List.of("Arnie"))).build(), "POST /abc/def from service to Arnie"),
                 of(InterceptedInteraction.builder().target("/abc/def").serviceName("service").body(BODY).type(RESPONSE).httpStatus("200").build(), "200 response from dest1 to service"),
                 of(InterceptedInteraction.builder().target("exchange").serviceName("service").body(BODY).type(PUBLISH).build(), "publish event from service to dest2"),
                 of(InterceptedInteraction.builder().target("exchange").serviceName("service").body(BODY).type(CONSUME).build(), "consume message from dest2 to service")

--- a/src/test/java/com/integreety/yatspec/e2e/integration/testapp/TestApplication.java
+++ b/src/test/java/com/integreety/yatspec/e2e/integration/testapp/TestApplication.java
@@ -1,12 +1,13 @@
 package com.integreety.yatspec.e2e.integration.testapp;
 
-import com.integreety.yatspec.e2e.integration.testapp.external.TestClient;
+import com.integreety.yatspec.e2e.integration.testapp.external.ExternalClientWithTargetHeader;
+import com.integreety.yatspec.e2e.integration.testapp.external.ExternalClient;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
-@EnableFeignClients( clients = TestClient.class)
+@EnableFeignClients( clients = {ExternalClient.class, ExternalClientWithTargetHeader.class})
 public class TestApplication {
 
 	public static void main(final String[] args) {

--- a/src/test/java/com/integreety/yatspec/e2e/integration/testapp/external/ExternalClient.java
+++ b/src/test/java/com/integreety/yatspec/e2e/integration/testapp/external/ExternalClient.java
@@ -3,8 +3,8 @@ package com.integreety.yatspec.e2e.integration.testapp.external;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 
-@FeignClient(name = "testClient", url = "http://localhost:${wiremock.server.port}")
-public interface TestClient {
+@FeignClient(name = "externalClient", url = "http://localhost:${wiremock.server.port}")
+public interface ExternalClient {
 
     @PostMapping("/external-api?message=from_feign")
     void post(String message);

--- a/src/test/java/com/integreety/yatspec/e2e/integration/testapp/external/ExternalClientWithTargetHeader.java
+++ b/src/test/java/com/integreety/yatspec/e2e/integration/testapp/external/ExternalClientWithTargetHeader.java
@@ -1,0 +1,22 @@
+package com.integreety.yatspec.e2e.integration.testapp.external;
+
+import feign.RequestInterceptor;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import static com.integreety.yatspec.e2e.integration.testapp.external.ExternalClientWithTargetHeader.ClientConfig;
+
+@FeignClient(name = "externalClientTargetHeader", url = "http://localhost:${wiremock.server.port}", configuration = ClientConfig.class)
+public interface ExternalClientWithTargetHeader {
+
+    @PostMapping("/external-api?message=from_feign")
+    void post(String message);
+
+    class ClientConfig {
+        @Bean
+        public RequestInterceptor headersInterceptor() {
+            return template -> template.header("Target-Name", "Downstream");
+        }
+    }
+}

--- a/src/test/java/com/integreety/yatspec/e2e/integration/testapp/listener/TestListener.java
+++ b/src/test/java/com/integreety/yatspec/e2e/integration/testapp/listener/TestListener.java
@@ -1,6 +1,7 @@
 package com.integreety.yatspec.e2e.integration.testapp.listener;
 
-import com.integreety.yatspec.e2e.integration.testapp.external.TestClient;
+import com.integreety.yatspec.e2e.integration.testapp.external.ExternalClientWithTargetHeader;
+import com.integreety.yatspec.e2e.integration.testapp.external.ExternalClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
@@ -11,11 +12,13 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class TestListener {
 
-    private final TestClient testClient;
+    private final ExternalClient externalClient;
+    private final ExternalClientWithTargetHeader externalClientWithTargetHeader;
 
     @RabbitListener(queues = "queue-listener")
     public void consume(final String message) {
         log.info("Consuming message={}", message);
-        testClient.post("from_listener");
+        externalClient.post("from_listener");
+        externalClientWithTargetHeader.post("from_listener");
     }
 }


### PR DESCRIPTION
Capture request headers for responses so that we can use the `Target-Name` and `Source-Name` headers for deriving source name and destination names for the sequence diagrams.

The response headers don't contain the original request headers so we need access to the original request headers on the response interactions.