### PR TITLE
Revert "fix: bump the springframework-dependencies group with 2 updates"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
     id 'java-library'
-    id 'org.springframework.boot' version '3.1.5' apply false
+    id 'org.springframework.boot' version '2.7.12' apply false
     id 'io.spring.dependency-management' version '1.1.3'
     id 'signing'
     id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
@@ -34,7 +34,7 @@ subprojects {
     apply plugin: 'io.spring.dependency-management'
     dependencyManagement {
         imports {
-            mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2022.0.4'
+            mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2021.0.6'
             mavenBom 'io.pivotal.spring.cloud:spring-cloud-services-dependencies:4.0.4'
             mavenBom SpringBootPlugin.BOM_COORDINATES
         }


### PR DESCRIPTION
Reverts lsd-consulting/lsd-distributed-interceptors#45

Seems to be a bug - didn't wait for the checks to run on the updated branch.. will tweak the CI triggers